### PR TITLE
supress POSIX class warning on line 1263

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
 
     - name: Run tests
       run: |
-        mknod /dev/tty c 5 0
         chmod 0666 /dev/tty
         perl Makefile.PL
         make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, macos-latest, windows-latest]
-        perl: [ '5.20', '5.32', '5.36' ]
+        runner: [ubuntu-latest] # macos-latest, windows-latest
+        perl: ['5.32'] # '5.36'
 
     runs-on: ${{matrix-runner}}
     name: OS ${{matrix.runner}} Perl ${{matrix.perl}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest] # macos-latest, windows-latest
-        perl: ['5.32'] # '5.36'
+        runner: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        perl: ['5.30', '5.32', '5.36']
 
     runs-on: ${{matrix.runner}}
     name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
 
     steps:
-    - uses: actions/checkout@v2
-
+    - uses: actions/checkout@v3
     - name: Set up Perl
       uses: shogo82148/actions-setup-perl@v1
       with:
@@ -34,6 +33,8 @@ jobs:
 
     - name: Run tests
       run: |
+        mknod /dev/tty c 5 0
+        chmod 0666 /dev/tty
         perl Makefile.PL
         make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: Perl
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        perl: [ '5.20', '5.32', '5.36' ]
+
+    runs-on: ${{matrix-runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{matrix.perl}}
+          distribution: ${{ (startsWith(matrix.runner, 'windows-') && 'strawberry') || 'default' }}
+
+    - name: Show Perl version
+      run: |
+        perl -v
+
+    - name: Install modules
+      run: |
+        cpanm -v
+        cpanm --installdeps --notest.
+
+    - name: Run tests
+      run: |
+        perl Makefile.PL
+        make test
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,7 @@ jobs:
 
     - name: Install modules
       run: |
-        cpanm -v
-        cpanm --installdeps --notest .
+        cpanm inc::Module::Install
 
     - name: Run tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         runner: [ubuntu-latest] # macos-latest, windows-latest
         perl: ['5.32'] # '5.36'
 
-    runs-on: ${{matrix-runner}}
+    runs-on: ${{matrix.runner}}
     name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
 
     - name: Run tests
       run: |
-        sudo chmod 0666 /dev/tty
         perl Makefile.PL
         make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install modules
       run: |
         cpanm -v
-        cpanm --installdeps --notest.
+        cpanm --installdeps --notest .
 
     - name: Run tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Run tests
       run: |
-        chmod 0666 /dev/tty
+        sudo chmod 0666 /dev/tty
         perl Makefile.PL
         make test
 

--- a/lib/Shell/POSIX/Select.pm
+++ b/lib/Shell/POSIX/Select.pm
@@ -68,8 +68,8 @@ $U_DEBUG=0;
 $DEBUG_FILT=4;
 # $DEBUG_FILT=0;
 
-$DEBUG=1; # force verbosity level for debugging messages
-# $DEBUG=0; # force verbosity level for debugging messages
+# $DEBUG=1; # force verbosity level for debugging messages
+$DEBUG=0; # force verbosity level for debugging messages
 
 $REPORT=1; # report subroutines when entered
 # $REPORT=0; # report subroutines when entered
@@ -1260,7 +1260,7 @@ sub show_subs {
 		 my $start=(shift || 0);
 		 my $length=(shift || 9999);
 
-		 $string =~ s/[^[:alpha:\d\s]]/-/g;	# control-chars screw up printing
+		 $string =~ s/[^[[:alpha:]\d\s]]/-/g;	# control-chars screw up printing
 # warn "Calling substr for parms $string/$start/$length\n";
 		 warn "$msg", $ON, substr ($string, $start, $length), $OFF, "\n";
 }


### PR DESCRIPTION
This PR supresses a syntax warning on line 1263 regarding the POSIX :alpha: regex class. Additionally, it removes the DEV env. DEBUG level to 0.
